### PR TITLE
Allow customizing of view

### DIFF
--- a/Providers/DashboardServiceProvider.php
+++ b/Providers/DashboardServiceProvider.php
@@ -4,6 +4,7 @@ use Illuminate\Support\ServiceProvider;
 use Modules\Dashboard\Entities\Widget;
 use Modules\Dashboard\Repositories\Cache\CacheWidgetDecorator;
 use Modules\Dashboard\Repositories\Eloquent\EloquentWidgetRepository;
+use Modules\Workshop\Manager\StylistThemeManager;
 
 class DashboardServiceProvider extends ServiceProvider
 {
@@ -32,6 +33,22 @@ class DashboardServiceProvider extends ServiceProvider
 
                 return new CacheWidgetDecorator($repository);
             }
+        );
+    }
+    
+    public function boot(StylistThemeManager $theme)
+    {
+        $this->publishes([
+            __DIR__ . '/../Resources/views' => base_path('resources/views/asgard/dashboard'),
+        ], 'views');
+
+        $this->app['view']->prependNamespace(
+            'dashboard',
+            base_path('resources/views/asgard/dashboard')
+        );
+        $this->app['view']->prependNamespace(
+            'dashboard',
+            $theme->find(config('asgard.core.core.admin-theme'))->getPath() . '/views/modules/dashboard'
         );
     }
 


### PR DESCRIPTION
This addresses couple of problems;

1) No ability to customize view for dashboard
2) No ability to ship view from withing Theme

Based on `CoreServiceProvider` we can not use `loadViewsFrom` as it appends to hints paths and never reaches intended override structure.
Also getting theme name from config is not always reliable as theme name and theme folder might differ, this addresses that.
